### PR TITLE
7 create headers for file and events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ build*
 *.user
 bin/
 .vscode
+config/oca.cfg
+config/papero.cfg
+data/
+sysctl_mem.cfg

--- a/include/daqserver.h
+++ b/include/daqserver.h
@@ -20,6 +20,7 @@ protected:
 private:
   std::vector<std::string> addressdet;
   std::vector<uint32_t> portdet;
+  std::vector<uint32_t> iddet;
   std::vector<de10_silicon_base*> det;
   std::string kdataPath = "./data/"; //!< Data file path
   volatile bool kStart; //!< Start event recording

--- a/include/makaClient.h
+++ b/include/makaClient.h
@@ -53,9 +53,9 @@ class makaClient : public tcpclient {
       Send cmd=setup
       Send configurations
     */
-    int setup(string _dataPath, vector<uint32_t> _detPorts,\
-                vector<std::string> _detAddrs, bool _dataToFile,\
-                bool _dataToOm, uint32_t _omPreScale);
+    int setup(string _dataPath, vector<uint32_t> _detIds,\
+                vector<uint32_t> _detPorts, vector<std::string> _detAddrs,\
+                bool _dataToFile, bool _dataToOm, uint32_t _omPreScale);
 
     /*
       Send cmd=runStart

--- a/include/makaMerger.h
+++ b/include/makaMerger.h
@@ -47,7 +47,7 @@ class makaMerger : public tcpServer {
     int kCmdLen = 24; //!<Server commands length, handshaken with the client
     thread kMerger3d; //!<Thread that hosts the merger
     bool kRunning = false; //!<Flag for run state
-    uint32_t kNEvts = 0; //!< Events in a run
+    uint32_t kNEvts = 0; //!<Events in a run
     //uint32_t kRunTime //!<Run time
     std::string kRunType;     //!<Run information: type
     uint32_t kRunNum;   //!<Run information: number
@@ -63,14 +63,17 @@ class makaMerger : public tcpServer {
     int kUdpPort = 8890;  //!< UDP server port
     udpClient* omClient;
 
-    
     //N clients for remote detectors
     vector<tcpclient*> kDet; //!<Remote detectors clients
 
-    //1 UDP socket for on-line monitor
-
     /*
-      Write file header
+      Write file header:
+        Known word
+        UNIX time of the run
+        MAKA git hash
+        Type [31:28], Data Version [27:16], # detectors [15:0]
+        Detector ID 0 [31:16], Detector ID 1 [15:0]
+        .......
     */
     int fileHeader(FILE* _dataFile);
 

--- a/include/makaMerger.h
+++ b/include/makaMerger.h
@@ -40,6 +40,7 @@ class makaMerger : public tcpServer {
     //Configuration parameters
     const uint32_t kOkVal  = 0xb01af1ca; //!< OK  answer to client
     const uint32_t kBadVal = 0x000cacca; //!< NOK Answer to client
+    vector<uint32_t> kDetIds; //!<Remote detectors ports
     vector<std::string> kDetAddrs; //!<Remote detectors addresses
     vector<uint32_t> kDetPorts; //!<Remote detectors ports
     string kDataPath = "./data/"; //!<Folder path where to store data
@@ -122,7 +123,7 @@ class makaMerger : public tcpServer {
     /*
       Add detector address and port to lists
     */
-    void addDet(char* _addr, int _port);
+    void addDet(uint32_t _id, char* _addr, int _port);
 
     /*
       Close clients for the remote detectors

--- a/include/paperoConfig.h
+++ b/include/paperoConfig.h
@@ -54,7 +54,7 @@ class paperoConfig
       uint16_t busyLen; //!Duration of extended busy
       uint16_t adcDelay; //!ADC delay (in clock cycles)
       bool ideTest; //!Test port of IDE1140
-      uint8_t chTest; //!IDE1140 channel connected to CAL port
+      uint16_t chTest; //!IDE1140 channel connected to CAL port
 
       void dump()
       {

--- a/src/daqserver.cpp
+++ b/src/daqserver.cpp
@@ -23,7 +23,7 @@ daqserver::daqserver(int port, int verb, std::string paperoCfgPath):tcpServer(po
 
   //Read paperoConfig parameters
   paperoConfig paperoConf(paperoCfgPath);
-  paperoConfVector = paperoConf.getParams(); //FIXME non glielo dovrei passare per referenza?
+  paperoConfVector = paperoConf.getParams();
   
   //Stop the run (if applicable) and reset
   kStart  = false;
@@ -53,8 +53,9 @@ void daqserver::SetUpConfigClients(){
   SetListDetectors();
 
   //Configure MAKA client
-  maka->setup(daqConf.dataFolder, portdet, addressdet, daqConf.makaSendToFile,\
-              daqConf.makaSendToOm, daqConf.makaOmPreScale);
+  maka->setup(daqConf.dataFolder, iddet, portdet, addressdet, \
+              daqConf.makaSendToFile, daqConf.makaSendToOm, \
+              daqConf.makaOmPreScale);
 
   //Start the socket
   SockStart();
@@ -72,10 +73,12 @@ void daqserver::SetUpConfigClients(){
 
 void daqserver::SetListDetectors(){
 
+  iddet.clear();
   addressdet.clear();
   portdet.clear();
 
   for (uint32_t ii=0; ii<paperoConfVector.size(); ii++) {
+    iddet.push_back(paperoConfVector[ii]->id);
     addressdet.push_back(paperoConfVector[ii]->ipAddr.data());
     portdet.push_back(paperoConfVector[ii]->tcpPort);
   }

--- a/src/makaClient.cpp
+++ b/src/makaClient.cpp
@@ -34,22 +34,24 @@ void makaClient::cmdLenHandshake(int _cmdLen){
 
 }
 
-int makaClient::setup(string _dataPath, vector<uint32_t> _detPorts,\
-                        vector<string> _detAddrs, bool _dataToFile,\
-                        bool _dataToOm, uint32_t _omPreScale){
+int makaClient::setup(string _dataPath, vector<uint32_t> _detIds,\
+                        vector<uint32_t> _detPorts, vector<string> _detAddrs,\
+                        bool _dataToFile, bool _dataToOm, uint32_t _omPreScale){
   //PAPERO opens the socket on OCAport+1
+  vector<uint32_t> makaIds;
   vector<uint32_t> makaPorts;
   vector<string> makaAddrs;
   //FIXME: Removing trigger board (for the moment, with a fixed IP address)
   for (size_t ii=0; ii<_detPorts.size(); ii++) {
     if (_detAddrs[ii]!="192.168.2.177") {
+      makaIds.push_back(_detIds[ii]);
       makaPorts.push_back(_detPorts[ii]+1);
       makaAddrs.push_back(_detAddrs[ii]);
     }
   }
 
 
-  configPacket* cp = new configPacket(makaPorts, makaAddrs, _dataPath,\
+  configPacket* cp = new configPacket(makaIds, makaPorts, makaAddrs, _dataPath,\
                                       _dataToFile, _dataToOm, _omPreScale);
   
   printf("%s) Configurations to be sent:\n", __METHOD_NAME__);

--- a/src/makaMerger.cpp
+++ b/src/makaMerger.cpp
@@ -39,11 +39,13 @@ makaMerger::~makaMerger(){
   Detector list and set-up
 ------------------------------------------------------------------------------*/
 void makaMerger::clearDetLists(){
+  kDetIds.clear();
   kDetAddrs.clear();
   kDetPorts.clear();
 }
 
-void makaMerger::addDet(char* _addr, int _port){
+void makaMerger::addDet(uint32_t _id, char* _addr, int _port){
+  kDetIds.push_back(_id);
   kDetAddrs.push_back(_addr);
   kDetPorts.push_back(_port);
 }
@@ -335,6 +337,7 @@ void makaMerger::processCmds(char* msg){
     
     //Copy configuration data
     kDataPath = cpRx->dataPath;
+    kDetIds   = cpRx->ids;
     kDetPorts = cpRx->ports;
     kDetAddrs = cpRx->addrs;
     kDataToFile = cpRx->dataToFile;

--- a/src/makaMerger.cpp
+++ b/src/makaMerger.cpp
@@ -121,11 +121,14 @@ int makaMerger::fileHeader(FILE* _dataFile){
             | (kDetAddrs.size() & 0xffff);
   writeRet += fwrite(&tempData, 4, 1, _dataFile); //Type, Data Version, # detectors
 
-  writeRet += fwrite(&kDetIds, sizeof(kDetIds[0]), kDetAddrs.size(), _dataFile);
-  //for (uint32_t ii=0; ii<kDetAddrs.size(); ii++) {
-  //  tempData = ((kDetIds[ii+1]&0x0000ffff)<<16) | (kDetIds[ii]&0x0000ffff);
-  //  writeRet += fwrite(&tempData, 4, 1, _dataFile); //Detector IDs...
-  //}
+  for (auto id : kDetIds){
+    writeRet += fwrite(&id, 2, 1, _dataFile); //Detector ID[n]
+  }
+  //0 padding to 32 bits
+  if (kDetAddrs.size()%2 == 1){
+    tempData = 0;
+    writeRet += fwrite(&tempData, 2, 1, _dataFile); //0 Padding
+  }
 
   return 0;
 }
@@ -365,7 +368,6 @@ void makaMerger::processCmds(char* msg){
     kDataToFile = cpRx->dataToFile;
     kDataToOm = cpRx->dataToOm;
     kOmPreScale = cpRx->omPreScale;
-
     
     free(rxData);
     

--- a/src/makaMerger.cpp
+++ b/src/makaMerger.cpp
@@ -223,7 +223,7 @@ int makaMerger::collector(FILE* _dataFile){
   std::bitset<64> replied{0};
   
   uint32_t evtHeader;
-  uint32_t evtLenHeader = sizeof(uint32_t)*(kDet.size() * 652 + 4);
+  uint32_t evtLenHeader = sizeof(uint32_t)*(kDet.size() * 651 + 3);
   bool headerWritten = false;
   bool dataToOm = kDataToOm & (kNEvts%kOmPreScale==0 ? true : false);
   //printf("%s) dataToOm value: %s", __METHOD_NAME__, dataToOm?"true":"false");

--- a/src/paperoConfig.cpp
+++ b/src/paperoConfig.cpp
@@ -131,7 +131,7 @@ int paperoConfig::config(istream& is)
           readOption<bool>(tempBuffer->ideTest, word);
           break;
         case 19:
-          readOption<uint8_t>(tempBuffer->chTest, word);
+          readOption<uint16_t>(tempBuffer->chTest, word);
           break;
         default:
           cout << __METHOD_NAME__ << ") Too many columns in config file." << endl;


### PR DESCRIPTION
MAKA writes file and event headers like in the following picture.

![image](https://user-images.githubusercontent.com/18463307/196883221-180dcb36-4671-4d20-9055-8901f741839a.png)

From the original format that we discussed, I removed the trailer, since I don't think it is useful. I can always add it, if you prefer. In the file header, the _type_ and _Data Version_ fields are constant, as well as _length_ in the event header.
